### PR TITLE
remove explicit credentials from aws client, and instead rely on AWS_PROFILE env var (and force dotenv to overwrite whatever global AWS_PROFILE is set with whatever is in .env)

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -1,8 +1,10 @@
+require "dotenv"
+Dotenv.load(overwrite: true)
+
 require "aws-sdk-secretsmanager"
 require "sinatra"
 require "pry-byebug"
 require "jwt"
-require "dotenv/load"
 require "nokogiri"
 
 require_relative "efiler_service"

--- a/extensions/efiler_api_client_auth.rb
+++ b/extensions/efiler_api_client_auth.rb
@@ -40,8 +40,7 @@ module Sinatra
     end
 
     def get_api_client_mef_credentials
-      aws_credentials = Aws::Credentials.new(ENV["AWS_ACCESS_KEY_ID"], ENV["AWS_SECRET_ACCESS_KEY"])
-      aws_client = Aws::SecretsManager::Client.new(region: "us-east-1", credentials: aws_credentials)
+      aws_client = Aws::SecretsManager::Client.new
       response = aws_client.get_secret_value(secret_id: "efiler-api-client-mef-credentials/#{api_client_name}")
       JSON.parse(response.secret_string).transform_keys { |k| k.to_sym }
     rescue Seahorse::Client::NetworkingError


### PR DESCRIPTION
per James' advisement