### PR TITLE
[TBE-200] comment out rescues so that errors appear in aws logs

### DIFF
--- a/app/controllers/api/v0/base_controller.rb
+++ b/app/controllers/api/v0/base_controller.rb
@@ -1,9 +1,9 @@
 class Api::V0::BaseController < ApplicationController
   before_action :verify_client_name_and_signature
-  rescue_from MefService::RetryableError, with: :retryable_mef_error
-  rescue_from ActionController::ParameterMissing, with: :show_errors
-  rescue_from Aws::SecretsManager::Errors::ResourceNotFoundException, with: :unauthorized
-  rescue_from JWT::VerificationError, with: :unauthorized
+  # rescue_from MefService::RetryableError, with: :retryable_mef_error
+  # rescue_from ActionController::ParameterMissing, with: :show_errors
+  # rescue_from Aws::SecretsManager::Errors::ResourceNotFoundException, with: :unauthorized
+  # rescue_from JWT::VerificationError, with: :unauthorized
 
   def retryable_mef_error
     render json: "Error contacting MeF, please try again", status: :bad_gateway


### PR DESCRIPTION
It's unclear why things are failing on demo, so we’re commenting out the rescues so that the Cloud Watch logs reflect the errors.