### PR TITLE
TEF-380: Fix some SolidQueue configuration issues

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -28,5 +28,7 @@ module EfilerApi
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+
+    config.solid_queue.shutdown_timeout = 30
   end
 end

--- a/config/queue.yml
+++ b/config/queue.yml
@@ -8,7 +8,7 @@ default: &default
       threads: 1
       processes: 3
       polling_interval: 0.1
-    - queues: webhook_callbacks
+    - queues: webhook_callback
       # We want our callbacks to execute concurrently, but we know they are threadsafe so we use a multi-threaded worker
       threads: 3
       processes: 1


### PR DESCRIPTION
1. fix typo in solidqueue config so that the queue name matches the jobs & webhook callback jobs actually get run
2. increase the shutdown timeout so that mef jobs have more of a chance to finish before they get killed after SolidQueue receives SIGTERM