### PR TITLE
TEF-343: return errors from acknowledgements, eliminate unused acknowledgement status, and fix typo in recognized mef statuses

### DIFF
--- a/app/services/mef/acks.rb
+++ b/app/services/mef/acks.rb
@@ -18,7 +18,7 @@ class Mef::Acks
         :failed
       end
 
-      if results.key? irs_submission_id
+      if results.key?(irs_submission_id)
         results[irs_submission_id][:status] = status  # take the most recent status, which will be last in the list
         results[irs_submission_id][:error_messages] += error_messages
       else

--- a/app/services/mef/acks.rb
+++ b/app/services/mef/acks.rb
@@ -1,37 +1,33 @@
 class Mef::Acks
   def self.parse_acks_response(response)
     doc = Nokogiri::XML(response)
-
     results = {}
 
     doc.css("AcknowledgementList Acknowledgement").each do |ack|
       irs_submission_id = ack.css("SubmissionId").text.strip
+      # MeF lists acks oldest-first. Multiple acks for one submission_id only
+      # arise from resubmission attempts (rejected as non-unique), so the first
+      # ack carries the original submission's outcome.
+      next if results.key?(irs_submission_id)
 
-      error_messages = ack.css("ValidationErrorList ValidationErrorGrp ErrorMessageTxt").map(&:text)
-
-      status = case ack.css("AcceptanceStatusTxt").text.strip.downcase
-      when "rejected", "r", "denied by irs"
-        :rejected
-      when "accepted", "a", "exception"
-        :accepted
-      else
-        :failed
-      end
-
-      if results.key?(irs_submission_id)
-        results[irs_submission_id][:status] = status  # take the most recent status, which will be last in the list
-        results[irs_submission_id][:error_messages] += error_messages
-      else
-        results[irs_submission_id] = {status:, error_messages:}
-      end
+      results[irs_submission_id] = {
+        irs_submission_id:,
+        status: status_code(ack),
+        error_messages: ack.css("ValidationErrorList ValidationErrorGrp ErrorMessageTxt").map(&:text)
+      }
     end
 
-    results.map do |irs_submission_id, parsed_acks|
-      {
-        irs_submission_id:,
-        status: parsed_acks[:status],
-        error_messages: parsed_acks[:error_messages].uniq
-      }
+    results.values
+  end
+
+  def self.status_code(ack)
+    case ack.css("AcceptanceStatusTxt").text.strip.downcase
+    when "rejected", "r", "denied by irs"
+      :rejected
+    when "accepted", "a", "exception"
+      :accepted
+    else
+      :failed
     end
   end
 end

--- a/app/services/mef/acks.rb
+++ b/app/services/mef/acks.rb
@@ -2,20 +2,36 @@ class Mef::Acks
   def self.parse_acks_response(response)
     doc = Nokogiri::XML(response)
 
-    doc.css("AcknowledgementList Acknowledgement").to_h do |ack|
-      irs_submission_id = ack.css("SubmissionId").text.strip
-      status = ack.css("AcceptanceStatusTxt").text.strip.downcase
+    results = {}
 
-      status_code = if ["rejected", "r", "denied by irs"].include?(status)
+    doc.css("AcknowledgementList Acknowledgement").each do |ack|
+      irs_submission_id = ack.css("SubmissionId").text.strip
+
+      error_messages = ack.css("ValidationErrorList ValidationErrorGrp ErrorMessageTxt").map(&:text)
+
+      status = case ack.css("AcceptanceStatusTxt").text.strip.downcase
+      when "rejected", "r", "denied by irs"
         :rejected
-      elsif ["accepted", "a"].include?(status)
+      when "accepted", "a", "exception"
         :accepted
-      elsif ["exception"].include?(status)
-        :accepted_but_imperfect
       else
         :failed
       end
-      [irs_submission_id, status_code]
+
+      if results.key? irs_submission_id
+        results[irs_submission_id][:status] = status  # take the most recent status, which will be last in the list
+        results[irs_submission_id][:error_messages] += error_messages
+      else
+        results[irs_submission_id] = {status:, error_messages:}
+      end
+    end
+
+    results.map do |irs_submission_id, parsed_acks|
+      {
+        irs_submission_id:,
+        status: parsed_acks[:status],
+        error_messages: parsed_acks[:error_messages].uniq
+      }
     end
   end
 end

--- a/app/services/mef/submissions_status.rb
+++ b/app/services/mef/submissions_status.rb
@@ -1,6 +1,6 @@
 class Mef::SubmissionsStatus
-  TRANSMITTED_STATUSES = ["Received", "Ready for Pickup", "Ready for Pick-Up", "Sent to State", "Received by State", "Rejected Acknowledgment Created"].to_set.freeze
-  READY_FOR_ACK_STATUSES = ["Denied by IRS", "Acknowledgement Received from State", "Acknowledgement Retrieved", "Notified"].to_set.freeze
+  TRANSMITTED_STATUSES = ["Received", "Ready for Pickup", "Ready for Pick-Up", "Sent to State", "Received by State"].to_set.freeze
+  READY_FOR_ACK_STATUSES = ["Denied by IRS", "Acknowledgement Received from State", "Acknowledgement Retrieved", "Notified", "Rejected Acknowledgement Created", "Rejected Acknowledgement Retrieved"].to_set.freeze
 
   def self.parse_submissions_status_response(response)
     doc = Nokogiri::XML(response)

--- a/spec/fixtures/files/irs_acknowledgement.xml
+++ b/spec/fixtures/files/irs_acknowledgement.xml
@@ -82,6 +82,39 @@
     <AcceptanceStatusTxt>R</AcceptanceStatusTxt>
     <ContainedAlertsInd>false</ContainedAlertsInd>
     <StatusDt>2021-07-16</StatusDt>
+    <ValidationErrorList errorCnt="2">
+      <ValidationErrorGrp errorId="1">
+        <DocumentId>NA</DocumentId>
+        <XpathContentTxt>/efile:Return/efile:ReturnHeader</XpathContentTxt>
+        <ErrorCategoryCd>Missing Data</ErrorCategoryCd>
+        <ErrorMessageTxt>ack error 1</ErrorMessageTxt>
+        <RuleNum>IND-189</RuleNum>
+        <SeverityCd>Reject and Stop</SeverityCd>
+        <FieldValueTxt/>
+      </ValidationErrorGrp>
+    </ValidationErrorList>
+  </Acknowledgement>
+  <Acknowledgement submissionVersionNum="2020v5.1" validatingSchemaVersionNum="2020v5.1">
+    <SubmissionId>9999992021197yrv4ref</SubmissionId>
+    <EFIN>999999</EFIN>
+    <TaxYr>2020</TaxYr>
+    <ExtndGovernmentCd>IRS</ExtndGovernmentCd>
+    <SubmissionTyp>1040</SubmissionTyp>
+    <ExtndSubmissionCategoryCd>IND</ExtndSubmissionCategoryCd>
+    <AcceptanceStatusTxt>R</AcceptanceStatusTxt>
+    <ContainedAlertsInd>false</ContainedAlertsInd>
+    <StatusDt>2021-07-17</StatusDt>
+    <ValidationErrorList errorCnt="2">
+      <ValidationErrorGrp errorId="1">
+        <DocumentId>NA</DocumentId>
+        <XpathContentTxt>/efile:Return/efile:ReturnHeader</XpathContentTxt>
+        <ErrorCategoryCd>Missing Data</ErrorCategoryCd>
+        <ErrorMessageTxt>ack error 2</ErrorMessageTxt>
+        <RuleNum>IND-189</RuleNum>
+        <SeverityCd>Reject and Stop</SeverityCd>
+        <FieldValueTxt/>
+      </ValidationErrorGrp>
+    </ValidationErrorList>
   </Acknowledgement>
   <Acknowledgement submissionVersionNum="2020v5.1" validatingSchemaVersionNum="2020v5.1">
     <SubmissionId>9999992021197yrv4rgh</SubmissionId>

--- a/spec/services/mef/acks_spec.rb
+++ b/spec/services/mef/acks_spec.rb
@@ -9,7 +9,7 @@ describe Mef::Acks do
         {irs_submission_id: "9999992021197yrv4rvl", status: :accepted, error_messages: []},
         {irs_submission_id: "9999992021197yrv4rab", status: :accepted, error_messages: []},
         {irs_submission_id: "9999992021197yrv4rcd", status: :rejected, error_messages: ["'DeviceId' in 'AtSubmissionCreationGrp' in 'FilingSecurityInformation' in the Return Header must have a value.", "'DeviceId' in 'AtSubmissionFilingGrp' in 'FilingSecurityInformation' in the Return Header must have a value."]},
-        {irs_submission_id: "9999992021197yrv4ref", status: :rejected, error_messages: ["ack error 1", "ack error 2"]},
+        {irs_submission_id: "9999992021197yrv4ref", status: :rejected, error_messages: ["ack error 1"]},
         {irs_submission_id: "9999992021197yrv4rgh", status: :rejected, error_messages: []},
         {irs_submission_id: "9999992021197yrv4rij", status: :accepted, error_messages: []},
         {irs_submission_id: "9999992021197yrv4rkl", status: :failed, error_messages: []}

--- a/spec/services/mef/acks_spec.rb
+++ b/spec/services/mef/acks_spec.rb
@@ -5,16 +5,14 @@ describe Mef::Acks do
     response = file_fixture("irs_acknowledgement.xml").read
 
     expect(described_class.parse_acks_response(response))
-      .to match_array(
-            [
-              ["9999992021197yrv4rvl", :accepted],
-              ["9999992021197yrv4rab", :accepted],
-              ["9999992021197yrv4rcd", :rejected],
-              ["9999992021197yrv4ref", :rejected],
-              ["9999992021197yrv4rgh", :rejected],
-              ["9999992021197yrv4rij", :accepted_but_imperfect],
-              ["9999992021197yrv4rkl", :failed]
-            ]
-          )
+      .to contain_exactly(
+        {irs_submission_id: "9999992021197yrv4rvl", status: :accepted, error_messages: []},
+        {irs_submission_id: "9999992021197yrv4rab", status: :accepted, error_messages: []},
+        {irs_submission_id: "9999992021197yrv4rcd", status: :rejected, error_messages: ["'DeviceId' in 'AtSubmissionCreationGrp' in 'FilingSecurityInformation' in the Return Header must have a value.", "'DeviceId' in 'AtSubmissionFilingGrp' in 'FilingSecurityInformation' in the Return Header must have a value."]},
+        {irs_submission_id: "9999992021197yrv4ref", status: :rejected, error_messages: []},
+        {irs_submission_id: "9999992021197yrv4rgh", status: :rejected, error_messages: []},
+        {irs_submission_id: "9999992021197yrv4rij", status: :accepted, error_messages: []},
+        {irs_submission_id: "9999992021197yrv4rkl", status: :failed, error_messages: []}
+      )
   end
 end

--- a/spec/services/mef/acks_spec.rb
+++ b/spec/services/mef/acks_spec.rb
@@ -9,7 +9,7 @@ describe Mef::Acks do
         {irs_submission_id: "9999992021197yrv4rvl", status: :accepted, error_messages: []},
         {irs_submission_id: "9999992021197yrv4rab", status: :accepted, error_messages: []},
         {irs_submission_id: "9999992021197yrv4rcd", status: :rejected, error_messages: ["'DeviceId' in 'AtSubmissionCreationGrp' in 'FilingSecurityInformation' in the Return Header must have a value.", "'DeviceId' in 'AtSubmissionFilingGrp' in 'FilingSecurityInformation' in the Return Header must have a value."]},
-        {irs_submission_id: "9999992021197yrv4ref", status: :rejected, error_messages: []},
+        {irs_submission_id: "9999992021197yrv4ref", status: :rejected, error_messages: ["ack error 1", "ack error 2"]},
         {irs_submission_id: "9999992021197yrv4rgh", status: :rejected, error_messages: []},
         {irs_submission_id: "9999992021197yrv4rij", status: :accepted, error_messages: []},
         {irs_submission_id: "9999992021197yrv4rkl", status: :failed, error_messages: []}


### PR DESCRIPTION
https://codeforamerica.atlassian.net/browse/TEF-343

## What was done?
- We now expose error messages for rejection acknowledgements. If there are multiple acknowledgements, we take the status and error messages from the first ack, since all subsequent acks for the same submission ID should just be rejections for any accidental re-submissions.
- Adjust the output format of our acks so that they can be more effectively expressed using StrongParams 
- fixes a typo in expected MeF output (Acknowledgment -> Acknowledgement) so that it matches real MeF output. I believe that this was previously in the `TRANSMITTED_STATUSES` incorrectly, due to this typo confusing us.
- removes the `:accepted_but_imperfect` status, as it not used in the gyraffe submission state machine. If we need to handle acks with `Exception` in them later, we can re-introduce something like this status.