### PR TITLE
TEF-649: Return structured error fields from MeF acknowledgements

### DIFF
--- a/app/services/mef/acks.rb
+++ b/app/services/mef/acks.rb
@@ -15,13 +15,13 @@ class Mef::Acks
         status: status_code(ack),
         errors: ack.css("ValidationErrorList ValidationErrorGrp").map do |grp|
           {
-            code:        grp.at_css("RuleNum")&.text,
-            category:    grp.at_css("ErrorCategoryCd")&.text,
-            severity:    grp.at_css("SeverityCd")&.text,
-            message:     grp.at_css("ErrorMessageTxt")&.text,
+            code: grp.at_css("RuleNum")&.text,
+            category: grp.at_css("ErrorCategoryCd")&.text,
+            severity: grp.at_css("SeverityCd")&.text,
+            message: grp.at_css("ErrorMessageTxt")&.text,
             field_value: grp.at_css("FieldValueTxt")&.text.presence,
-            xpath:       grp.at_css("XpathContentTxt")&.text,
-            document_id: grp.at_css("DocumentId")&.text,
+            xpath: grp.at_css("XpathContentTxt")&.text,
+            document_id: grp.at_css("DocumentId")&.text
           }
         end
       }

--- a/app/services/mef/acks.rb
+++ b/app/services/mef/acks.rb
@@ -13,7 +13,17 @@ class Mef::Acks
       results[irs_submission_id] = {
         irs_submission_id:,
         status: status_code(ack),
-        error_messages: ack.css("ValidationErrorList ValidationErrorGrp ErrorMessageTxt").map(&:text)
+        errors: ack.css("ValidationErrorList ValidationErrorGrp").map do |grp|
+          {
+            code:        grp.at_css("RuleNum")&.text,
+            category:    grp.at_css("ErrorCategoryCd")&.text,
+            severity:    grp.at_css("SeverityCd")&.text,
+            message:     grp.at_css("ErrorMessageTxt")&.text,
+            field_value: grp.at_css("FieldValueTxt")&.text.presence,
+            xpath:       grp.at_css("XpathContentTxt")&.text,
+            document_id: grp.at_css("DocumentId")&.text,
+          }
+        end
       }
     end
 

--- a/spec/services/mef/acks_spec.rb
+++ b/spec/services/mef/acks_spec.rb
@@ -6,13 +6,13 @@ describe Mef::Acks do
 
     expect(described_class.parse_acks_response(response))
       .to contain_exactly(
-        {irs_submission_id: "9999992021197yrv4rvl", status: :accepted, error_messages: []},
-        {irs_submission_id: "9999992021197yrv4rab", status: :accepted, error_messages: []},
-        {irs_submission_id: "9999992021197yrv4rcd", status: :rejected, error_messages: ["'DeviceId' in 'AtSubmissionCreationGrp' in 'FilingSecurityInformation' in the Return Header must have a value.", "'DeviceId' in 'AtSubmissionFilingGrp' in 'FilingSecurityInformation' in the Return Header must have a value."]},
-        {irs_submission_id: "9999992021197yrv4ref", status: :rejected, error_messages: ["ack error 1"]},
-        {irs_submission_id: "9999992021197yrv4rgh", status: :rejected, error_messages: []},
-        {irs_submission_id: "9999992021197yrv4rij", status: :accepted, error_messages: []},
-        {irs_submission_id: "9999992021197yrv4rkl", status: :failed, error_messages: []}
+        {irs_submission_id: "9999992021197yrv4rvl", status: :accepted, errors: []},
+        {irs_submission_id: "9999992021197yrv4rab", status: :accepted, errors: []},
+        {irs_submission_id: "9999992021197yrv4rcd", status: :rejected, errors: [{code: "IND-189", category: "Missing Data", severity: "Reject and Stop", message: "'DeviceId' in 'AtSubmissionCreationGrp' in 'FilingSecurityInformation' in the Return Header must have a value.", field_value: nil, xpath: "/efile:Return/efile:ReturnHeader", document_id: "NA"}, {code: "IND-190", category: "Missing Data", severity: "Reject and Stop", message: "'DeviceId' in 'AtSubmissionFilingGrp' in 'FilingSecurityInformation' in the Return Header must have a value.", field_value: "142111111", xpath: "/efile:Return/efile:ReturnHeader", document_id: "NA"}]},
+        {irs_submission_id: "9999992021197yrv4ref", status: :rejected, errors: [{code: "IND-189", category: "Missing Data", severity: "Reject and Stop", message: "ack error 1", field_value: nil, xpath: "/efile:Return/efile:ReturnHeader", document_id: "NA"}]},
+        {irs_submission_id: "9999992021197yrv4rgh", status: :rejected, errors: []},
+        {irs_submission_id: "9999992021197yrv4rij", status: :accepted, errors: []},
+        {irs_submission_id: "9999992021197yrv4rkl", status: :failed, errors: []}
       )
   end
 end


### PR DESCRIPTION
https://codeforamerica.atlassian.net/browse/TEF-649

Replace flat error_messages strings with per-ValidationErrorGrp hashes (code, category, severity, message, field_value, xpath, document_id) so consumers can classify rejections instead of regexing strings.

Output is parsed and used in https://github.com/codeforamerica/gyraffe/pull/437