### PR TITLE
Authenticate with callback endpoints by adding shared secret in headers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ group :development, :test do
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
   gem "brakeman", require: false
   gem "standard", require: false
+  gem "climate_control"
   gem "webmock"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,7 @@ GEM
     brakeman (8.0.4)
       racc
     builder (3.3.0)
+    climate_control (1.2.0)
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
     crack (1.0.1)
@@ -371,6 +372,7 @@ DEPENDENCIES
   aws-sdk-secretsmanager
   bootsnap
   brakeman
+  climate_control
   debug
   dotenv-rails
   faraday

--- a/app/jobs/webhook_callback_job.rb
+++ b/app/jobs/webhook_callback_job.rb
@@ -4,7 +4,10 @@ class WebhookCallbackJob < ApplicationJob
   def perform(api_request_id, webhook_url, payload)
     payload_with_api_request_id = payload.merge({api_request_id:})
     webhook_uri = URI.parse(webhook_url)
-    conn = Faraday.new(url: webhook_uri.origin, headers: {"Content-Type" => "application/json"})
+    conn = Faraday.new(url: webhook_uri.origin, headers: {
+      "Content-Type" => "application/json",
+      "X-EFiler-Callback-Secret" => ENV.fetch("EFILER_API_CALLBACK_SECRET")
+    })
     conn.post(webhook_uri.path) do |req|
       req.options.timeout = 5
       req.body = payload_with_api_request_id.to_json

--- a/spec/controllers/api/v0/efile_controller_spec.rb
+++ b/spec/controllers/api/v0/efile_controller_spec.rb
@@ -4,19 +4,25 @@ describe Api::V0::EfileController, type: :controller do
   let(:api_client_name) { "api_client" }
   let(:api_request_id) { "fake-uuid" }
   let(:mef_credentials) { {mef_env: "test", app_sys_id: "foo", etin: "bar", cert_base64: "baz"} }
+  let(:callback_secret) { "test-secret" }
 
   before do
     allow_any_instance_of(described_class).to receive(:verify_client_name_and_signature).and_return(true)
     allow_any_instance_of(described_class).to receive(:api_client_name).and_return(api_client_name)
     allow_any_instance_of(described_class).to receive(:api_request_id).and_return(api_request_id)
     allow(MefService).to receive(:get_mef_credentials).and_return(mef_credentials)
+    ENV["EFILER_API_CALLBACK_SECRET"] = callback_secret
   end
 
   after do
-    stub_request(:post, webhook_url).with(body: expected_webhook_request_body)
+    stub_request(:post, webhook_url).with(
+      body: expected_webhook_request_body,
+      headers: {"X-EFiler-Callback-Secret" => callback_secret}
+    )
     clear_performed_jobs
     perform_enqueued_jobs(only: WebhookCallbackJob)
     assert_performed_jobs 1
+    ENV.delete("EFILER_API_CALLBACK_SECRET")
   end
 
   describe "#submit" do

--- a/spec/controllers/api/v0/efile_controller_spec.rb
+++ b/spec/controllers/api/v0/efile_controller_spec.rb
@@ -6,12 +6,13 @@ describe Api::V0::EfileController, type: :controller do
   let(:mef_credentials) { {mef_env: "test", app_sys_id: "foo", etin: "bar", cert_base64: "baz"} }
   let(:callback_secret) { "test-secret" }
 
+  around { |example| ClimateControl.modify(EFILER_API_CALLBACK_SECRET: callback_secret) { example.run } }
+
   before do
     allow_any_instance_of(described_class).to receive(:verify_client_name_and_signature).and_return(true)
     allow_any_instance_of(described_class).to receive(:api_client_name).and_return(api_client_name)
     allow_any_instance_of(described_class).to receive(:api_request_id).and_return(api_request_id)
     allow(MefService).to receive(:get_mef_credentials).and_return(mef_credentials)
-    ENV["EFILER_API_CALLBACK_SECRET"] = callback_secret
   end
 
   after do
@@ -22,7 +23,6 @@ describe Api::V0::EfileController, type: :controller do
     clear_performed_jobs
     perform_enqueued_jobs(only: WebhookCallbackJob)
     assert_performed_jobs 1
-    ENV.delete("EFILER_API_CALLBACK_SECRET")
   end
 
   describe "#submit" do


### PR DESCRIPTION
https://codeforamerica.atlassian.net/browse/TEF-615

This authenticates with the EFiler API callback endpoints in SimpleFile by adding a shared secret to the request headers.