### PR TITLE
TEF-782: Filter sensitive data from logs

### DIFF
--- a/app/controllers/api/v0/base_controller.rb
+++ b/app/controllers/api/v0/base_controller.rb
@@ -16,18 +16,24 @@ class Api::V0::BaseController < ApplicationController
   end
 
   def showable_error(exception)
-    Rails.logger.error("Encountered showable error: #{exception}")
+    Rails.logger.error("Encountered showable error: #{loggable_exception(exception)}")
     render json: exception.message, status: :bad_request
   end
 
   def aws_error(exception)
-    Rails.logger.error("Encountered error while contacting AWS: #{exception}")
+    Rails.logger.error("Encountered error while contacting AWS: #{loggable_exception(exception)}")
     head :unauthorized
   end
 
   def jwt_error(exception)
-    Rails.logger.error("Encountered JWT verification error: #{exception}")
+    Rails.logger.error("Encountered JWT verification error: #{loggable_exception(exception)}")
     head :unauthorized
+  end
+
+  # Exception messages here can embed submitted/IRS data, so production logs the class alone;
+  # non-production logs the full exception for debugging.
+  def loggable_exception(exception)
+    Rails.env.production? ? exception.class : exception
   end
 
   def verify_client_name_and_signature

--- a/app/jobs/mef/mef_job.rb
+++ b/app/jobs/mef/mef_job.rb
@@ -10,7 +10,11 @@ module Mef
     end
 
     def log_and_respond_with_error(job, exception)
-      Rails.logger.error("MefJob #{job} has been discarded due to #{exception}")
+      # exception can wrap the MeF SDK audit log / Java output (taxpayer data), so production logs the
+      # class and correlates by request id; non-production logs it in full for debugging. Either way
+      # the full detail is still relayed to the client via the webhook below.
+      loggable_exception = Rails.env.production? ? exception.class : exception
+      Rails.logger.error("#{job.class.name} (api_request_id=#{job.api_request_id}) has been discarded due to #{loggable_exception}")
       WebhookCallbackJob.perform_later(
         api_request_id,
         webhook_url,

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -3,6 +3,17 @@
 # Configure parameters to be partially matched (e.g. passw matches password) and filtered from the log file.
 # Use this to limit dissemination of sensitive information.
 # See the ActiveSupport::ParameterFilter documentation for supported notations and behaviors.
+#
+# This API receives tax-return submission bundles. The bundle itself is the most sensitive payload
+# (XML containing SSNs, names, addresses, income, bank routing/account numbers), so it is filtered
+# from request parameter logging. These filters do NOT scrub values interpolated directly into log
+# messages — keep PII out of those by hand (see MefJob / BaseController).
 Rails.application.config.filter_parameters += [
-  :passw, :email, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn, :cvv, :cvc
+  :passw, :email, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn, :cvv, :cvc,
+
+  # The tax-return submission bundle (base64 ZIP of return XML); never useful in logs
+  :submission_bundle,
+
+  # Client callback URL (may carry credentials/tokens in the path or query)
+  :webhook_url
 ]

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -11,7 +11,8 @@
 Rails.application.config.filter_parameters += [
   :passw, :email, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn, :cvv, :cvc,
 
-  # The tax-return submission bundle (base64 ZIP of return XML); never useful in logs
+  # The tax-return submission bundle (base64 ZIP of return XML): sensitive PII, an opaque multi-MB
+  # blob as-logged, and available for debugging through the stored artifact rather than the request log
   :submission_bundle,
 
   # Client callback URL (may carry credentials/tokens in the path or query)

--- a/spec/controllers/api/v0/efile_controller_spec.rb
+++ b/spec/controllers/api/v0/efile_controller_spec.rb
@@ -183,6 +183,31 @@ describe Api::V0::EfileController, type: :controller do
         assert_performed_jobs 1
         expect(MefService).to have_received(:run_efiler_command).with(mef_credentials, "acks", "123", "456")
       end
+
+      it "logs the discard with the exception class and request id but not the error message in production" do
+        allow(Rails.env).to receive(:production?).and_return(true)
+        allow(Rails.logger).to receive(:error).and_call_original
+
+        get :acks, params: {id: [123, 456], webhook_url: webhook_url}
+        assert_raises(StandardError) do
+          perform_enqueued_jobs(only: Mef::AcksJob)
+        end
+
+        expect(Rails.logger).to have_received(:error)
+          .with(/Mef::AcksJob \(api_request_id=fake-uuid\) has been discarded due to StandardError/)
+        expect(Rails.logger).not_to have_received(:error).with(/fake non-retryable error/)
+      end
+
+      it "logs the full exception message in non-production environments" do
+        allow(Rails.logger).to receive(:error).and_call_original
+
+        get :acks, params: {id: [123, 456], webhook_url: webhook_url}
+        assert_raises(StandardError) do
+          perform_enqueued_jobs(only: Mef::AcksJob)
+        end
+
+        expect(Rails.logger).to have_received(:error).with(/fake non-retryable error/)
+      end
     end
   end
 end


### PR DESCRIPTION
## Ticket

[TEF-782](https://codeforamerica.atlassian.net/browse/TEF-782)

## Summary

Companion to the [Gyraffe PR](https://github.com/codeforamerica/gyraffe/pull/749). Keeps tax-return PII out of production logs while leaving non-production verbose for debugging the MeF integration (which can't be reproduced locally). Same policy: scrub in production only.

## Changes

- **`config.filter_parameters`** — filter `submission_bundle` (the base64 return XML) and `webhook_url` (may carry tokens) in all environments.
- **`Mef::MefJob`** — on discard, production logs the job class + `api_request_id` + exception class; non-prod logs the full exception (which can wrap the MeF SDK audit log / Java output). The full `detailed_message` is still relayed to the client via the webhook, so nothing is lost for forensics.
- **`Api::V0::BaseController`** — the three `rescue_from` handlers log `exception.class` in production and the full exception in non-prod.

## Testing

- `efile_controller_spec` — discard logging asserts class-only in production and the full message in non-prod.
- `bundle exec rspec` green; `bundle exec standardrb` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TEF-782]: https://codeforamerica.atlassian.net/browse/TEF-782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ